### PR TITLE
Update header label to SSW

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,7 +32,7 @@ export function Header({ categories }: { categories: Category[] }) {
       id: category.id,
     })),
     { href: "/about", label: "RIDE JOBについて", id: "about" },
-    { href: "https://ridejob-cms.online/ssw", label: "特定技能外国人", id: "ssw" },
+    { href: "https://ridejob-cms.online/ssw", label: "SSW", id: "ssw" },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- update header navigation label from Japanese text to 'SSW'

## Testing
- `pnpm lint` *(fails: `next` not found because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a86759de88322a5f3d126f9bf3dc4